### PR TITLE
Docker 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # DyakonovAlex_microservices
+
 DyakonovAlex microservices repository
 
 ## Homework 15

--- a/README.md
+++ b/README.md
@@ -1,6 +1,74 @@
 # DyakonovAlex_microservices
 DyakonovAlex microservices repository
 
+## Homework 15
+
+### Работа с сетью в docker
+
+#### None network driver
+
+- ```docker run -ti --rm --network none joffotron/docker-net-tools -c ifconfig```
+
+#### Host network driver
+
+- ```docker run -ti --rm --network host joffotron/docker-net-tools -c ifconfig```
+- ```docker-machine ssh docker-host ifconfig```
+- Результаты одинаковы, так как используется сеть хоста.
+- Запущен несколько раз ```docker run --network host -d nginx```.
+В ```docker ps``` видно, что остался запущен только один контейнер. Это происходит из-за того, что используется один интерфейс и порт уже занят.
+- ```docker kill $(docker ps -q)```  
+- ```docker-machine ssh docker-host 'sudo ln -s /var/run/docker/netns /var/run/netns'```
+- ```docker-machine ssh docker-host 'sudo ip netns'```  
+- Повторены запуски контейнеров с использованием драйверов ```none``` и ```host``` и просмотрено, как меняется список namespace-ов
+
+#### Bridge network driver  
+
+- ```docker network create reddit --driver bridge```
+- Запущены контейнеры приложения
+- Проверено, что приложение функционирует некорректно. Созданы новые контейнеры с присвоением сетевых псевдонимов  
+- Приложение функционирует корректно
+
+##### Запуск проекта в 2-х bridge сетях
+
+- Созданы docker-сети
+- Запущены контейнеры
+- Убедились, что приложени работает некорректно, так как Docker при инициализации контейнера может подключить к нему только 1 сеть  
+- Подключены дополнительные сети для контейнеров post и comment  
+- Приложение работает корректно  
+- Произведена установка пакета bridge-utils на docker-host
+- Выполнена команда ```docker network ls``` и найдены ID сетей, созданных в рамках проекта
+- Выполнено на docker-host ```ifconfig | grep br``` и найдены bridge-интерфейсы для каждой из сетей  
+- Просмотрена информация о интерфейсе с помощью команды ```brctl show br-24373a954c6f```
+- Выполнено ```sudo iptables -nL -t nat```
+- Выполнено ```ps ax | grep docker-proxy```. Проверено, что docker-proxy слушает порт 9292  
+
+### Использование docker-compose
+
+- Установлен docker-compose ```pip install docker-compose```
+- Добавлен файл docker-compose.yml
+- Собраны образы и запущены контейнеры
+
+```bash
+export USERNAME=happydyakonov
+docker-compose up -d
+docker-compose ps
+```
+
+- Проверено, что приложение работает.
+
+#### Задания для самостоятельной работы  
+
+- Изменён ```docker-compose.yml``` под кейс с множеством сетей, сетевых алиасов
+- Параметризированы с помощью переменных окружений:
+  - порт публикации сервиса ui
+  - версии сервисов
+- Параметризованные параметры записаны в отдельный файл ```.env```  
+- Проверено, что без использования команд ```source``` и ```export``` ```docker-compose``` подхватывает переменные из этого файла  
+- Базовое имя проекта, по умолчанию, образуется на основе имени директории из которой производится запуск  
+  Способы изменения:
+  - запустить ```docker-compose up -d -p new_project_name```  
+  - задать в переменной окружения ```COMPOSE_PROJECT_NAME```  
+
 ## Homework 14
 
 ### Сделано

--- a/src/.env.example
+++ b/src/.env.example
@@ -1,0 +1,20 @@
+# Your username
+USERNAME=happydyakonov
+
+# Project name
+COMPOSE_PROJECT_NAME=otus
+
+# UI Port
+UI_PORT=9292
+
+# UI version
+UI_VERSION=1.0
+
+# POST version
+POST_VERSION=1.0
+
+# COMMENT version
+COMMENT_VERSION=1.0
+
+# MONGO version
+MONGO_VERSION=3.2

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,4 +1,3 @@
-docker-compose.yml
 build_info.txt
 prometheus/
 

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -4,3 +4,4 @@ prometheus/
 
 ## python specific
 *.pyc
+.env

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -1,0 +1,52 @@
+---
+version: '3.3'
+services:
+  post_db:
+    image: mongo:${MONGO_VERSION}
+    volumes:
+      - post_db:/data/db
+    networks:
+      back_net:
+       aliases:
+       - post_db
+       - comment_db
+  ui:
+    build: ./ui
+    image: ${USERNAME}/ui:${UI_VERSION}
+    ports:
+      - ${UI_PORT}:${UI_PORT}/tcp
+    networks:
+      - front_net
+  post:
+    build: ./post-py
+    image: ${USERNAME}/post:${POST_VERSION}
+    networks:
+      back_net:
+       aliases:
+       - comment
+      front_net:
+       aliases:
+       - comment
+  comment:
+    build: ./comment
+    image: ${USERNAME}/comment:${COMMENT_VERSION}
+    networks:
+      back_net:
+       aliases:
+       - post
+      front_net:
+       aliases:
+       - post
+
+volumes:
+  post_db:
+
+networks:
+  back_net:
+    ipam:
+      config:
+        - subnet: 10.0.2.0/24
+  front_net:
+    ipam:
+      config:
+        - subnet: 10.0.1.0/24

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -7,9 +7,9 @@ services:
       - post_db:/data/db
     networks:
       back_net:
-       aliases:
-       - post_db
-       - comment_db
+        aliases:
+          - post_db
+          - comment_db
   ui:
     build: ./ui
     image: ${USERNAME}/ui:${UI_VERSION}
@@ -22,21 +22,21 @@ services:
     image: ${USERNAME}/post:${POST_VERSION}
     networks:
       back_net:
-       aliases:
-       - comment
+        aliases:
+          - comment
       front_net:
-       aliases:
-       - comment
+        aliases:
+          - comment
   comment:
     build: ./comment
     image: ${USERNAME}/comment:${COMMENT_VERSION}
     networks:
       back_net:
-       aliases:
-       - post
+        aliases:
+          - post
       front_net:
-       aliases:
-       - post
+        aliases:
+          - post
 
 volumes:
   post_db:


### PR DESCRIPTION
# Выполнено ДЗ № 15

 - [x] Основное ДЗ
 - [ ] Задание со *

## В процессе сделано:
### Работа с сетью в docker

#### None network driver

- ```docker run -ti --rm --network none joffotron/docker-net-tools -c ifconfig```

#### Host network driver

- ```docker run -ti --rm --network host joffotron/docker-net-tools -c ifconfig```
- ```docker-machine ssh docker-host ifconfig```
- Результаты одинаковы, так как используется сеть хоста.
- Запущен несколько раз ```docker run --network host -d nginx```.
В ```docker ps``` видно, что остался запущен только один контейнер. Это происходит из-за того, что используется один интерфейс и порт уже занят.
- ```docker kill $(docker ps -q)```  
- ```docker-machine ssh docker-host 'sudo ln -s /var/run/docker/netns /var/run/netns'```
- ```docker-machine ssh docker-host 'sudo ip netns'```  
- Повторены запуски контейнеров с использованием драйверов ```none``` и ```host``` и просмотрено, как меняется список namespace-ов

#### Bridge network driver  

- ```docker network create reddit --driver bridge```
- Запущены контейнеры приложения
- Проверено, что приложение функционирует некорректно. Созданы новые контейнеры с присвоением сетевых псевдонимов  
- Приложение функционирует корректно

##### Запуск проекта в 2-х bridge сетях

- Созданы docker-сети
- Запущены контейнеры
- Убедились, что приложени работает некорректно, так как Docker при инициализации контейнера может подключить к нему только 1 сеть  
- Подключены дополнительные сети для контейнеров post и comment  
- Приложение работает корректно  
- Произведена установка пакета bridge-utils на docker-host
- Выполнена команда ```docker network ls``` и найдены ID сетей, созданных в рамках проекта
- Выполнено на docker-host ```ifconfig | grep br``` и найдены bridge-интерфейсы для каждой из сетей  
- Просмотрена информация о интерфейсе с помощью команды ```brctl show br-24373a954c6f```
- Выполнено ```sudo iptables -nL -t nat```
- Выполнено ```ps ax | grep docker-proxy```. Проверено, что docker-proxy слушает порт 9292  

### Использование docker-compose

- Установлен docker-compose ```pip install docker-compose```
- Добавлен файл docker-compose.yml
- Собраны образы и запущены контейнеры

```bash
export USERNAME=happydyakonov
docker-compose up -d
docker-compose ps
```

- Проверено, что приложение работает.

#### Задания для самостоятельной работы  

- Изменён ```docker-compose.yml``` под кейс с множеством сетей, сетевых алиасов
- Параметризированы с помощью переменных окружений:
  - порт публикации сервиса ui
  - версии сервисов
- Параметризованные параметры записаны в отдельный файл ```.env```  
- Проверено, что без использования команд ```source``` и ```export``` ```docker-compose``` подхватывает переменные из этого файла  
- Базовое имя проекта, по умолчанию, образуется на основе имени директории из которой производится запуск  
  Способы изменения:
  - запустить ```docker-compose up -d -p new_project_name```  
  - задать в переменной окружения ```COMPOSE_PROJECT_NAME``` 

## Как запустить проект:
 - Например, запустить команду X в директории Y

## Как проверить работоспособность:
 - Например, перейти по ссылке http://localhost:8080

## PR checklist
 - [ ] Выставил label с номером домашнего задания
 - [ ] Выставил label с темой домашнего задания
